### PR TITLE
Add a log folder by default in a ruby app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,6 @@ COPY pry-config /root/.pryrc
 # Create base directory for the application
 RUN mkdir -p /app
 WORKDIR /app
+
+# Create the logs folder
+RUN mkdir -p /app/log/

--- a/Dockerfile.trusty
+++ b/Dockerfile.trusty
@@ -33,3 +33,6 @@ COPY rspec-config /root/.rspec
 # Create base directory for the application
 RUN mkdir -p /app
 WORKDIR /app
+
+# Create the logs folder
+RUN mkdir -p /app/log/


### PR DESCRIPTION
### Why?

When starting a container as a dependency that uses `lograge` (for instance), the `log` folder needs to be present.

We don't have the problem when the main application is using `lograge`, since we always mount a volume to it (that contains the log folder).