### PR TITLE
Add the logs in a volume for each application.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ RUN mkdir -p /app
 WORKDIR /app
 
 # Create the logs folder
-RUN mkdir -p /app/log/
+VOLUME ["/app/log"]

--- a/Dockerfile.trusty
+++ b/Dockerfile.trusty
@@ -35,4 +35,4 @@ RUN mkdir -p /app
 WORKDIR /app
 
 # Create the logs folder
-RUN mkdir -p /app/log/
+VOLUME ["/app/log"]


### PR DESCRIPTION
Thanks to @cimnine for the suggestion!

### Why?

* The logs are persisted, even though your drop your container
* Can be accessible from other containers (Logstash & co)
* It would be for all of our ruby applications at once, which is quite a cool feature :).