### PR TITLE
Also setup the test DB when using the db_setup scripts.

### DIFF
--- a/scripts/setup_mysql
+++ b/scripts/setup_mysql
@@ -10,5 +10,5 @@ then
   echo "🐬 Database exists, doing nothing."
 else
   echo "🐬 Setup Database"
-  bundle exec rake db:setup
+  bundle exec rake db:setup db:test:prepare
 fi

--- a/scripts/setup_pg
+++ b/scripts/setup_pg
@@ -11,7 +11,7 @@ then
   echo "🐘 Database exists, doing nothing."
 else
   echo "🐘 Setup Database"
-  bundle exec rake db:setup
+  bundle exec rake db:setup db:test:prepare
 fi
 
 unset $PGPASSWORD


### PR DESCRIPTION
### Why?

So that we have only one command to use in development and test environments.