### PR TITLE
💄 Keep the images small by just installing what is neccessary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ MAINTAINER development@nine.ch
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommend; \
+    echo 'APT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01nosuggests
+
 # Install essential dev tools
 RUN apt-get update &&  apt-get -qq install -y \
       locales tzdata \

--- a/Dockerfile.trusty
+++ b/Dockerfile.trusty
@@ -7,6 +7,9 @@ ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommend; \
+    echo 'APT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01nosuggests
+
 # Install essential dev tools
 RUN    apt-get update \
     && apt-get -qq install -y software-properties-common \


### PR DESCRIPTION
> By default, Ubuntu installs recommended but not suggested packages. With --no-install-recommends, only the main dependencies (packages in the Depends field) are installed.

https://askubuntu.com/a/65093

This makes the `--no-install-recommends` part permanent via the configuration.