### PR TITLE
Update nokogiri to 1.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN bundle config jobs 2
 
 # Pre-install some widely used gems
 RUN gem install --no-document nokogiri -v '1.7.1' && \
+    gem install --no-document nokogiri -v '1.7.2' && \
     gem install --no-document pg -v '0.20.0' && \
     gem install --no-document capybara-webkit -v '1.14.0'
 

--- a/Dockerfile.trusty
+++ b/Dockerfile.trusty
@@ -37,6 +37,7 @@ RUN bundle config jobs 2
 
 # Pre-install some widely used gems
 RUN gem install --no-document nokogiri -v '1.7.1' && \
+    gem install --no-document nokogiri -v '1.7.2' && \
     gem install --no-document pg -v '0.20.0' && \
     gem install --no-document capybara-webkit -v '1.14.0'
 


### PR DESCRIPTION
We keep the old version until most of the apps are up-to-date.