### PR TITLE
Do not wait for the mysql instance to be ready in setup_mysql.

### DIFF
--- a/scripts/setup_mysql
+++ b/scripts/setup_mysql
@@ -4,7 +4,6 @@
 # Description:
 # Setup the database if it doesn't exist.
 
-waitfortcp ${MYSQL_HOST:-mysql} ${MYSQL_PORT:-3306}
 if echo "use $1; show tables" | mysql --host=${MYSQL_HOST:-mysql} --user=${MYSQL_USER:-root} --password=${MYSQL_PASSWORD:-root} | grep schema_migrations 2>&1 > /dev/null
 then
   echo "🐬 Database exists, doing nothing."


### PR DESCRIPTION
### Why?

1. Not defined in `postgresql` script.
2. The setup should do one thing only: the DB setup. We have a wait script that we can/should invoke outside of it.