### PR TITLE
add rubymine support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,6 @@ RUN    install-gems.sh \
 RUN mkdir -p /app
 WORKDIR /app
 
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 # Create the logs folder
 RUN mkdir -p /app/log/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+include ./env_make
+
+.PHONY: build push shell run start stop rm release
+
+build:
+	docker build -t $(NS)/$(REPO):$(VERSION) .
+
+push:
+	docker push $(NS)/$(REPO):$(VERSION)
+
+shell:
+	docker run --rm --name $(NAME)-$(INSTANCE) -i -t $(PORTS) $(VOLUMES) $(ENV) $(NS)/$(REPO):$(VERSION) /bin/bash
+
+run:
+	docker run --rm --name $(NAME)-$(INSTANCE) $(PORTS) $(VOLUMES) $(ENV) $(NS)/$(REPO):$(VERSION)
+
+start:
+	docker run -d --name $(NAME)-$(INSTANCE) $(PORTS) $(VOLUMES) $(ENV) $(NS)/$(REPO):$(VERSION)
+
+stop:
+	docker stop $(NAME)-$(INSTANCE)
+
+rm:
+	docker rm $(NAME)-$(INSTANCE)
+
+release: build
+	make push -e VERSION=$(VERSION)
+
+default: build

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ The following Git alises exist:
 * `git l`: Some nicer looking and more compact `git log`
 * `git s`: A short version of `git status`
 
+## Rubymine
+
+This image can be used with rubymine to test and debug applications
+
+To enable debugging nothing further is needed, provided that your application includes the [appropriate debugging gems](https://blog.jetbrains.com/ruby/2017/06/rubymine-2017-2-eap-5-debugging-with-docker-compose/).
+
+To enable testing set the environmental variable RUBYMINE_TESTS to true.
+If your application requires bootstrapping scripts to run before debugging is started place them in the container dir /app/docker/boostrap/ and they will be auto sourced
+
 ## About
 
 This docker image is currently maintained and funded by [nine](https://nine.ch).

--- a/env_make
+++ b/env_make
@@ -1,0 +1,6 @@
+NS = docker-registry.nine.ch/ninech
+VERSION ?= trusty
+
+REPO = ruby
+NAME = ruby
+INSTANCE = head

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ -z ${RUBYMINE_TESTS+x} ]]; then
+    exec "$@"
+else
+    if [ -d "/app/docker/bootstrap" ]; then
+        # If you put application bootstrapping scripts in a docker/bootstrap folder they will always be run before tests start
+        for f in /app/docker/bootstrap/*; do source $f; done
+    fi
+    xvfb-run -a "$@"
+fi


### PR DESCRIPTION
Added rubymine support in this image. This creates no changes for non rubymine users and all projects will continue to work as is.

As some projects need some bootstrapping before the tests can be run successfully I have created the option to put bootstrapping scripts in the docker/bootstrap folder and they will be automatically sourced in Rubymine runs via the entrypoint. 
As a concrete example this means that in future applications like Kuba should put their db bootstapping details into a script in the docker/bootstrap folder, rather than directly in the start or test start CMD scripts and you can source them to load them appropriately for non Rubymine use cases.

As this change doesn't affect non rubymine users and is extremely simply to enact I think it would be acceptable just to do it when a rubymine user touches an active project, but it would be awesome if we kept this in mind (i can adjust the wiki to also mention this if agreed) and in future projects can use this structure in the first place. Is this agreeable to you all?

The other addition that I made here (and happy to remove it if you dont think it's helpful) is to add a makefile that can be used to really easily build and push this image.