### PR TITLE
Add imagemagick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update &&  apt-get -qq install -y \
       netcat-openbsd \
       git \
       nodejs nodejs-legacy npm \
+      imagemagick \
       xvfb qt5-default libqt5webkit5-dev libqtwebkit-dev \
       build-essential \
       dbus gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x \


### PR DESCRIPTION
This change might be a bit controversial.

When using the Gitlab Pipelines we have to possibilities. One is very
easy: Just pick the ruby base image and run the tests in there. There
other one is to build your own image and to the whole setup with
docker-compose.

This change enables knowledge-base base to be built with the first
solution. It makes the whole process easier. But it adds another
dependency to the base image which is not needed for most other apps.

Fat image vs. easier build process. Pick your poison.