### PR TITLE
Proposal: Silence the log out for db initializations

### DIFF
--- a/scripts/setup_mysql
+++ b/scripts/setup_mysql
@@ -9,5 +9,5 @@ then
   echo "🐬 Database exists, doing nothing."
 else
   echo "🐬 Setup Database"
-  bundle exec rake db:setup db:test:prepare
+  bundle exec rake db:setup db:test:prepare >/dev/null
 fi

--- a/scripts/setup_pg
+++ b/scripts/setup_pg
@@ -11,7 +11,7 @@ then
   echo "🐘 Database exists, doing nothing."
 else
   echo "🐘 Setup Database"
-  bundle exec rake db:setup db:test:prepare
+  bundle exec rake db:setup db:test:prepare >/dev/null
 fi
 
 unset $PGPASSWORD


### PR DESCRIPTION
This change sends all stdout logs to /dev/null. The logs of the db initialisation of a Rails app is normally not useful but very noisy.